### PR TITLE
Expand demo data and add container build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ docker run \
   ghcr.io/wundergraph/cosmo/router:latest
 ```
 
+## Building and Publishing Subgraph Containers
+
+Each subgraph includes a `Dockerfile` so you can build and publish images to
+GitHub Container Registry (GHCR). Replace `<owner>` with your GitHub user or
+organization.
+
+```bash
+# Build and push the posts subgraph
+docker build -t ghcr.io/<owner>/subgraph-posts:latest ./subgraph-posts
+docker push ghcr.io/<owner>/subgraph-posts:latest
+
+# Build and push the users subgraph
+docker build -t ghcr.io/<owner>/subgraph-users:latest ./subgraph-users
+docker push ghcr.io/<owner>/subgraph-users:latest
+```
+
+These images can then be pulled by TrueNAS or any other container host.
+
 ## CI/CD
 
 GitHub actions are setup to do schema checks on pull requests and schema publish on push to main.
@@ -79,6 +97,8 @@ query {
   publishers {
     id
     name
+    foundedYear
+    totalComicsPublished
   }
 }
 ```
@@ -95,6 +115,8 @@ query {
     name
     publisher {
       name
+      foundedYear
+      totalComicsPublished
     }
   }
 }

--- a/subgraph-posts/data.ts
+++ b/subgraph-posts/data.ts
@@ -29,4 +29,24 @@ export const characters = [
     name: "Thor",
     publisherId: "marvel",
   },
+  {
+    id: "7",
+    name: "Green Lantern",
+    publisherId: "dc",
+  },
+  {
+    id: "8",
+    name: "The Flash",
+    publisherId: "dc",
+  },
+  {
+    id: "9",
+    name: "Captain America",
+    publisherId: "marvel",
+  },
+  {
+    id: "10",
+    name: "Black Widow",
+    publisherId: "marvel",
+  },
 ];

--- a/subgraph-users/data.ts
+++ b/subgraph-users/data.ts
@@ -2,9 +2,13 @@ export const publishers = [
   {
     id: "dc",
     name: "DC Comics",
+    foundedYear: 1934,
+    totalComicsPublished: 12000,
   },
   {
     id: "marvel",
     name: "Marvel Comics",
+    foundedYear: 1939,
+    totalComicsPublished: 32000,
   },
 ];

--- a/subgraph-users/schema.graphql
+++ b/subgraph-users/schema.graphql
@@ -1,6 +1,8 @@
 type Publisher @key(fields: "id") {
   id: ID!
   name: String!
+  foundedYear: Int!
+  totalComicsPublished: Int!
 }
 
 extend type Character @key(fields: "id") {


### PR DESCRIPTION
## Summary
- add more sample characters
- enrich publisher details with founding year and comics count
- document container build and publish steps
- extend example queries with the new publisher fields

## Testing
- `npm run build` in `subgraph-posts` *(fails: Cannot find type definition file for 'uuid')*
- `npm run build` in `subgraph-users` *(fails: Cannot find module '@apollo/server')*

------
https://chatgpt.com/codex/tasks/task_e_6872d151ac008320a380ee1600ad6246